### PR TITLE
Support static property on component wrapper by the translate() HOC

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-i18n-jed",
-  "version": "3.1.0",
+  "version": "3.0.0",
   "description": "React i18n wrapper for jed, based on gettext",
   "author": "App Annie Engineering",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-i18n-jed",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "React i18n wrapper for jed, based on gettext",
   "author": "App Annie Engineering",
   "files": [

--- a/src/translate.js
+++ b/src/translate.js
@@ -4,18 +4,20 @@ import hoistStatics from 'hoist-non-react-statics';
 import type { I18nType } from '.';
 import { I18nContext } from './I18nProvider';
 
-declare class TranslatedComponent<OP> extends React$Component<OP> {
-    static WrappedComponent: Class<React$Component<OP>>;
+declare class TranslatedComponent<OP, ST> extends React$Component<OP> {
+    static WrappedComponent: Class<React$Component<OP>> & $Shape<ST>;
     static displayName: ?string;
     props: OP;
     state: void;
 }
 
-declare type TranslatedComponentClass<OP> = Class<TranslatedComponent<OP>>;
+declare type TranslatedComponentClass<OP, ST> = Class<TranslatedComponent<OP, ST>>;
 
-function translate<Props>(
-    WrappedComponent: React.ComponentType<$Supertype<{ i18n: I18nType } & Props>>
-): TranslatedComponentClass<Props> {
+function translate<
+    Props,
+    Com: React.ComponentType<$Supertype<{ i18n: I18nType } & Props>>,
+    ST: $Subtype<{ [_: $Keys<Com>]: any }>
+>(WrappedComponent: Com): TranslatedComponentClass<Props, ST> & ST {
     class Translate extends React.Component<Props> {
         static WrappedComponent = WrappedComponent;
         static displayName = `Translate(${WrappedComponent.displayName ||


### PR DESCRIPTION
 HOC component should export static properties, or flow could not check them.
