### PR TITLE
Remove ST generic type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-i18n-jed",
-  "version": "3.1.2",
+  "version": "3.1.1",
   "description": "React i18n wrapper for jed, based on gettext",
   "author": "App Annie Engineering",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-i18n-jed",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "React i18n wrapper for jed, based on gettext",
   "author": "App Annie Engineering",
   "files": [

--- a/src/translate.js
+++ b/src/translate.js
@@ -17,9 +17,8 @@ type InjectedProps = { i18n: I18nType };
 
 function translate<
     Com: React.ComponentType<*>,
-    Props: $Diff<React.ElementConfig<Com>, InjectedProps>,
-    ST: { [_: $Keys<Com>]: any }
->(WrappedComponent: Com): TranslatedComponentClass<Props, Com> & ST {
+    Props: $Diff<React.ElementConfig<Com>, InjectedProps>
+>(WrappedComponent: Com): TranslatedComponentClass<Props, Com> {
     class Translate extends React.Component<Props> {
         static WrappedComponent = WrappedComponent;
 


### PR DESCRIPTION
Removed ST type. The ST caused the flow checking broken.

Now it won't support Static Props, but works well for props check. 

If we need use static props in our code, could only use $FlowFixMe for now.