### PR TITLE
Reduce amount of generic type

### DIFF
--- a/__test__/__snapshots__/test.js.snap
+++ b/__test__/__snapshots__/test.js.snap
@@ -50,6 +50,39 @@ exports[`<I18nProvider> children get i18n from I18nProvider 2`] = `
 </I18nProvider>
 `;
 
+exports[`translate Component render anonymous component 1`] = `
+<Translate(Component)
+  i18n={
+    Object {
+      "gettext": [Function],
+      "lang": "en-US",
+      "ngettext": [Function],
+      "npgettext": [Function],
+      "pgettext": [Function],
+    }
+  }
+  testProp="required"
+>
+  <Component
+    i18n={
+      Object {
+        "gettext": [Function],
+        "lang": "en-US",
+        "ngettext": [Function],
+        "npgettext": [Function],
+        "pgettext": [Function],
+      }
+    }
+    testProp="required"
+  >
+    <div>
+      My
+      required
+    </div>
+  </Component>
+</Translate(Component)>
+`;
+
 exports[`translate Component render translated component 1`] = `
 <Translate(TestElement)
   i18n={

--- a/__test__/good-type.flow.js
+++ b/__test__/good-type.flow.js
@@ -24,6 +24,7 @@ const ComponentA = ({
 );
 
 const TComponentA = translate(ComponentA);
+export const ComponentA2 = translate<typeof ComponentA>(ComponentA);
 result = <TComponentA content="foo">bar</TComponentA>;
 result = (
     <TComponentA.WrappedComponent content="foo" i18n={mockI18n}>
@@ -55,6 +56,7 @@ class ComponentB extends React.PureComponent<{
 }
 
 const TComponentB = translate(ComponentB);
+export const ComponentB2 = translate<typeof ComponentB>(ComponentB);
 result = <TComponentB content="foo">bar</TComponentB>;
 
 // Case 3: class component with static
@@ -85,6 +87,7 @@ class ComponentC extends React.Component<{
 }
 
 const TComponentC = translate(ComponentC);
+export const ComponentC2 = translate<typeof ComponentC>(ComponentC);
 result = <TComponentC content="foo">bar</TComponentC>;
 
 ComponentC.method('foo');
@@ -96,10 +99,14 @@ const TComponentDisplayName = TComponentC.displayName;
 
 class DisplayComponent1 extends React.Component<{}> {
     render() {
-        return <div><TComponentC content="foo" >child</TComponentC></div>
+        return (
+            <div>
+                <TComponentC content="foo">child</TComponentC>
+            </div>
+        );
     }
 }
-const display1 = <DisplayComponent1 />
+const display1 = <DisplayComponent1 />;
 
 // Case 4: class component with defaultProps
 class ComponentD extends React.Component<{
@@ -128,29 +135,34 @@ class ComponentD extends React.Component<{
     }
 }
 
-const componentD = <ComponentD age={12} i18n={mockI18n} />
+const componentD = <ComponentD age={12} i18n={mockI18n} />;
 const TComponentD = translate(ComponentD);
+export const ComponentD2 = translate<typeof ComponentD>(ComponentD);
 
 result = <TComponentD age={12} />;
 
 class DisplayComponent2 extends React.Component<{}> {
     render() {
-        return <div><TComponentD age={12} /></div>
+        return (
+            <div>
+                <TComponentD age={12} />
+            </div>
+        );
     }
 }
-const display2= <DisplayComponent2 />
+const display2 = <DisplayComponent2 />;
 
 // Case 5: React stateless component
-const StatelessCom = ({name, i18n}: {name: string, i18n: I18nType}) => <div>{i18n.gettext('S')}</div>
+const StatelessCom = ({ name, i18n }: { name: string, i18n: I18nType }) => (
+    <div>{i18n.gettext('S')}</div>
+);
 const TStatelessCom = translate(StatelessCom);
 
 result = <TStatelessCom name="Kate" />;
 
 class DisplayComponent3 extends React.Component<{}> {
     render() {
-        return <div>{result}</div>
+        return <div>{result}</div>;
     }
 }
-const display3 = <DisplayComponent3/>
-
-
+const display3 = <DisplayComponent3 />;

--- a/__test__/test.js
+++ b/__test__/test.js
@@ -83,6 +83,19 @@ describe('translate Component', () => {
         const localizedEle = mount(<LocalizedEle i18n={mockI18n} testProp="required" />);
         expect(localizedEle).toMatchSnapshot();
     });
+
+    it('render anonymous component', () => {
+        const LocalizedEle = translate(
+            ({ i18n, testProp }: { i18n: I18nType, testProp: string }) => (
+                <div>
+                    {i18n.gettext('My')}
+                    {testProp}
+                </div>
+            )
+        );
+        const localizedEle = mount(<LocalizedEle i18n={mockI18n} testProp="required" />);
+        expect(localizedEle).toMatchSnapshot();
+    });
 });
 
 describe('mock i18n', () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3149,9 +3149,9 @@
       }
     },
     "flow-bin": {
-      "version": "0.87.0",
-      "resolved": "https://registry.npmjs.org/flow-bin/-/flow-bin-0.87.0.tgz",
-      "integrity": "sha512-mnvBXXZkUp4y6A96bR5BHa3q1ioIIN2L10w5osxJqagAakTXFYZwjl0t9cT3y2aCEf1wnK6n91xgYypQS/Dqbw==",
+      "version": "0.84.0",
+      "resolved": "https://registry.npmjs.org/flow-bin/-/flow-bin-0.84.0.tgz",
+      "integrity": "sha512-ocji8eEYp+YfICsm+F6cIHUcD7v5sb0/ADEXm6gyUKdjQzmSckMrPUdZtyfP973t3YGHKliUMxMvIBHyR5LbXQ==",
       "dev": true
     },
     "flow-copy-source": {
@@ -4583,6 +4583,14 @@
             "is-buffer": "^1.1.5"
           }
         }
+      }
+    },
+    "hoist-non-react-statics": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.2.1.tgz",
+      "integrity": "sha512-TFsu3TV3YLY+zFTZDrN8L2DTFanObwmBLpWvJs1qfUuEQ5bTAdFcwfx2T/bsCXfM9QHSLvjfP+nihEl0yvozxw==",
+      "requires": {
+        "react-is": "^16.3.2"
       }
     },
     "home-or-tmp": {
@@ -8688,8 +8696,7 @@
     "react-is": {
       "version": "16.6.3",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.6.3.tgz",
-      "integrity": "sha512-u7FDWtthB4rWibG/+mFbVd5FvdI20yde86qKGx4lVUTWmPlSWQ4QxbBIrrs+HnXGbxOUlUzTAP/VDmvCwaP2yA==",
-      "dev": true
+      "integrity": "sha512-u7FDWtthB4rWibG/+mFbVd5FvdI20yde86qKGx4lVUTWmPlSWQ4QxbBIrrs+HnXGbxOUlUzTAP/VDmvCwaP2yA=="
     },
     "react-test-renderer": {
       "version": "16.6.3",

--- a/src/translate.js
+++ b/src/translate.js
@@ -16,15 +16,17 @@ declare class TranslatedComponent<OP> extends React$Component<OP> {
 
 declare type TranslatedComponentClass<OP> = Class<TranslatedComponent<OP>>;
 
-function translate<
-    Com: React$ComponentType<*>,
-    Props: $Diff<React.ElementConfig<Com>, InjectedProps>
->(WrappedComponent: Com): TranslatedComponentClass<Props> {
-    class Translate extends React.Component<Props> {
+function translate<Com: React$ComponentType<*>>(
+    WrappedComponent: Com
+): TranslatedComponentClass<$Diff<React.ElementConfig<Com>, InjectedProps>> {
+    const name = WrappedComponent.displayName || WrappedComponent.name || 'Component';
+
+    class Translate extends React.Component<
+        $Diff<React.ElementConfig<Com>, InjectedProps>
+    > {
         static WrappedComponent = WrappedComponent;
 
-        static displayName = `Translate(${WrappedComponent.displayName ||
-            WrappedComponent.name})`;
+        static displayName = `Translate(${name})`;
 
         render() {
             return (


### PR DESCRIPTION
This PR is trying to reach a middle step between current status and the status of https://github.com/appannie/react-i18n-jed/pull/16

By removing the second generic type, we actually add extra coverage around the locations where the context cause flow to silently set the type to `any`. (this catched 15 errors on our main repo)

And it'll allow us to easily fill in the generic type manually in order to be 100% sure the types aren't `any`. This will make it easily usable with both flow 0.84 and and 0.89.

```js
export default translate<typeof Comp>(Comp);
```