### PR TITLE
Fix typescript type syntax errors

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,13 +1,16 @@
-import { ReactNode, ComponentType } from 'react';
+import { ReactNode, ComponentType, ComponentClass } from 'react';
 
 declare namespace reactI18nJed {
     export const I18nProvider: ComponentType<{ i18n: I18n; children?: ReactNode }>;
+    interface Translate {
+        <P extends { i18n: I18n }>(x: ComponentType<P>): ComponentClass<Omit<P, 'i18n'>>;
+    }
 
-    export const translate: ComponentType<T>;
+    export const translate: Translate;
 
     export const useI18n: () => I18n;
 
-    export const sprintf: (...rest: string) => string;
+    export const sprintf: (arg0: string, ...rest: (string | number)[]) => string;
 
     export interface I18n {
         lang: string;


### PR DESCRIPTION
In the ts environment, translate leads to anyscript. And the type file of translate has a syntax error.

![image](https://user-images.githubusercontent.com/11007351/105790870-09572e00-5fc0-11eb-969d-f457e877ba4a.png)

This mr adds paradigm and paradigm constraint information for translate, and fixes grammatical errors.

Reported-by: Wang Hongxin <wanghongxin@outlook.com>
Tested-by: Wang Hongxin <wanghongxin@outlook.com>